### PR TITLE
Add multi-monitor keybindings

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -254,6 +254,16 @@ bind = $mainMod, mouse_up, workspace, e-1
 bindm = $mainMod, mouse:272, movewindow
 bindm = $mainMod, mouse:273, resizewindow
 
+# Multi-monitor keybindings
+bind = $mainMod CTRL, left, focusmonitor, l
+bind = $mainMod CTRL, right, focusmonitor, r
+bind = $mainMod CTRL, up, focusmonitor, u
+bind = $mainMod CTRL, down, focusmonitor, d
+bind = $mainMod SHIFT, left, movewindow, mon:l
+bind = $mainMod SHIFT, right, movewindow, mon:r
+bind = $mainMod SHIFT, up, movewindow, mon:u
+bind = $mainMod SHIFT, down, movewindow, mon:d
+
 
 ##############################
 ### WINDOWS AND WORKSPACES ###


### PR DESCRIPTION
## Summary
- Add keybindings for focusing monitors in all directions (left, right, up, down) using SUPER+CTRL+direction
- Add keybindings for moving windows to monitors in all directions using SUPER+SHIFT+direction