### PR TITLE
Add Wayland environment variables

### DIFF
--- a/hyprland.conf
+++ b/hyprland.conf
@@ -61,6 +61,9 @@ exec-once = hyprpaper &
 
 env = XCURSOR_SIZE,24
 env = HYPRCURSOR_SIZE,24
+env = XDG_CURRENT_DESKTOP,Hyprland
+env = XDG_SESSION_TYPE,wayland
+env = QT_QPA_PLATFORM,wayland
 
 
 #####################


### PR DESCRIPTION
## Summary
- Add XDG_CURRENT_DESKTOP=Hyprland for proper desktop detection
- Add XDG_SESSION_TYPE=wayland to specify session type  
- Add QT_QPA_PLATFORM=wayland to ensure Qt apps use Wayland backend

These changes improve compatibility and ensure applications run correctly in the Hyprland Wayland session.